### PR TITLE
ipc workaround for gh944

### DIFF
--- a/sound/pci/hda/hda_codec.c
+++ b/sound/pci/hda/hda_codec.c
@@ -2946,20 +2946,6 @@ static int hda_codec_runtime_resume(struct device *dev)
 #endif /* CONFIG_PM */
 
 #ifdef CONFIG_PM_SLEEP
-static int hda_codec_force_resume(struct device *dev)
-{
-	int ret;
-
-	/* The get/put pair below enforces the runtime resume even if the
-	 * device hasn't been used at suspend time.  This trick is needed to
-	 * update the jack state change during the sleep.
-	 */
-	pm_runtime_get_noresume(dev);
-	ret = pm_runtime_force_resume(dev);
-	pm_runtime_put(dev);
-	return ret;
-}
-
 static int hda_codec_pm_suspend(struct device *dev)
 {
 	dev->power.power_state = PMSG_SUSPEND;
@@ -2969,7 +2955,7 @@ static int hda_codec_pm_suspend(struct device *dev)
 static int hda_codec_pm_resume(struct device *dev)
 {
 	dev->power.power_state = PMSG_RESUME;
-	return hda_codec_force_resume(dev);
+	return pm_runtime_force_resume(dev);
 }
 
 static int hda_codec_pm_freeze(struct device *dev)
@@ -2981,13 +2967,13 @@ static int hda_codec_pm_freeze(struct device *dev)
 static int hda_codec_pm_thaw(struct device *dev)
 {
 	dev->power.power_state = PMSG_THAW;
-	return hda_codec_force_resume(dev);
+	return pm_runtime_force_resume(dev);
 }
 
 static int hda_codec_pm_restore(struct device *dev)
 {
 	dev->power.power_state = PMSG_RESTORE;
-	return hda_codec_force_resume(dev);
+	return pm_runtime_force_resume(dev);
 }
 #endif /* CONFIG_PM_SLEEP */
 


### PR DESCRIPTION
This reverts commit b5a236c175b0d984552a5f7c9d35141024c2b261.

The reverted patch causes SOF IPC timeouts by forcing
a suspend-resume cycle on the HDA codec.

This patch is meant to enable S3 stress-testing to continue
while proper fix is being developed.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>