### PR TITLE
ASoC: SOF: hda: set autosuspend delay for hda bus device

### DIFF
--- a/sound/soc/sof/intel/hda-codec.c
+++ b/sound/soc/sof/intel/hda-codec.c
@@ -95,6 +95,7 @@ static int hda_codec_probe(struct snd_sof_dev *sdev, int address)
 int hda_codec_probe_bus(struct snd_sof_dev *sdev)
 {
 	struct hdac_bus *bus = sof_to_bus(sdev);
+	struct hda_bus *hbus = sof_to_hbus(sdev);
 	int i, ret;
 
 	/* probe codecs in avail slots */
@@ -110,6 +111,9 @@ int hda_codec_probe_bus(struct snd_sof_dev *sdev)
 			return ret;
 		}
 	}
+
+	/* set autosuspend delay for hda bus device */
+	snd_hda_set_power_save(hbus, SND_SOF_SUSPEND_DELAY_MS);
 
 	return 0;
 }


### PR DESCRIPTION
Set the autosuspend delay for hda bus device. This prevents
the hda codec device from entering runtime suspend
when running stress tests involving opening/closing
streams one after the other.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>